### PR TITLE
fix(config): avoid domain in baseurl

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "https://zola-exp1.changeme-domain.dev"
+base_url = "/"
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true


### PR DESCRIPTION
Avoid hardcoding comain in `base_url` as the site may be deployed under different domains in different stages (preview, dev, prod, etc.).